### PR TITLE
Convert OneCycle into a 3 Stage LR Scheduler

### DIFF
--- a/snn_voice/model/module/module.py
+++ b/snn_voice/model/module/module.py
@@ -108,7 +108,8 @@ class Module(pl.LightningModule, ABC):
             max_lr=self.lr,
             steps_per_epoch=steps_per_epoch,
             epochs=self.trainer.max_epochs,
-            # verbose=True
+            pct_start=0.2,
+            three_phase=True,
         )
 
         return {

--- a/snn_voice/model/module/module.py
+++ b/snn_voice/model/module/module.py
@@ -15,6 +15,7 @@ class Module(pl.LightningModule, ABC):
     def __init__(
             self,
             lr: float = LEARNING_RATE,
+            one_cycle_kwargs: dict = None
     ):
         """ Initializes an abstract datamodule for inheritance
 
@@ -23,7 +24,10 @@ class Module(pl.LightningModule, ABC):
         """
 
         super().__init__()
+        if one_cycle_kwargs is None:
+            one_cycle_kwargs = {}
         self.lr = lr
+        self.one_cycle_kwargs = one_cycle_kwargs
         self.topk = TOPK
         self.criterion = nn.CrossEntropyLoss()
         # We'll set a static example, exposing the correct sizes is too much of a workaround
@@ -103,13 +107,14 @@ class Module(pl.LightningModule, ABC):
             else len(self.trainer.datamodule.train_dataloader())
 
         # LR Scheduler through Cosine Annealing
+
         lr_scheduler = OneCycleLR(
             optimizer,
             max_lr=self.lr,
             steps_per_epoch=steps_per_epoch,
             epochs=self.trainer.max_epochs,
-            pct_start=0.2,
             three_phase=True,
+            **self.one_cycle_kwargs
         )
 
         return {

--- a/snn_voice/model/module/module.py
+++ b/snn_voice/model/module/module.py
@@ -30,6 +30,7 @@ class Module(pl.LightningModule, ABC):
         self.one_cycle_kwargs = one_cycle_kwargs
         self.topk = TOPK
         self.criterion = nn.CrossEntropyLoss()
+        self.save_hyperparameters()
         # We'll set a static example, exposing the correct sizes is too much of a workaround
         # self.example_input_array = torch.rand([32, 1, 4000])
 


### PR DESCRIPTION
# Major Changes
- Add `three_phase=True` into `OneCycle`.
- Add `one_cycle_kwargs` for custom `OneCycle` args
- Add `save_hyperparameters()` to track experiments