### PR TITLE
Fix `run-all` not existing.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,4 +40,4 @@ jobs:
           python -m pytest tests/unit_tests
       - name: Test make run
         run: |
-          make run-all test_config=True HYDRA_FULL_ERROR=1
+          make run-all-cnn test_config=True HYDRA_FULL_ERROR=1


### PR DESCRIPTION
# Major Changes
- Fix `run-all` not existing anymore on `run.sh`, use `run-all-cnn` instead